### PR TITLE
Add repository editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{c,h,cu,py}]
+indent_style = space
+indent_size = 4
+
+[*.bat]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Fixes #30

## Summary

Adds a root `.editorconfig` so editors can apply the repository's expected line endings and indentation automatically.

## Details

- Sets UTF-8, CRLF line endings, and final newlines for all files
- Uses 4-space indentation for C, CUDA, header, and Python files
- Uses 2-space indentation for batch scripts

## Validation

- `git diff --check`

I did not run `build.bat` because this is an editor configuration-only change and the documented build requires Windows/MSVC/CUDA.